### PR TITLE
Fix Content-Signal directive format in robots.txt

### DIFF
--- a/e2e/agent-ready.spec.ts
+++ b/e2e/agent-ready.spec.ts
@@ -24,12 +24,14 @@ test.describe("agent-ready endpoints", () => {
       "Amazonbot",
     ];
     for (const bot of bots) {
-      expect(body).toContain(`User-agent: ${bot}`);
+      expect(body).toMatch(
+        new RegExp(
+          `^User-agent: ${bot}\\nContent-Signal: search=yes, ai-input=yes, ai-train=yes\\nAllow: /$`,
+          "m",
+        ),
+      );
     }
 
-    expect(body).toContain(
-      "Content-Signal: search=yes, ai-input=yes, ai-train=yes",
-    );
     expect(body).toMatch(/^Sitemap: https?:\/\/.+\/sitemap-index\.xml$/m);
   });
 

--- a/e2e/agent-ready.spec.ts
+++ b/e2e/agent-ready.spec.ts
@@ -8,7 +8,9 @@ test.describe("agent-ready endpoints", () => {
     expect(res.status()).toBe(200);
     const body = await res.text();
 
-    expect(body).toMatch(/^User-agent: \*\nAllow: \//m);
+    expect(body).toMatch(
+      /^User-agent: \*\nContent-Signal: [^\n]+\nAllow: \//m,
+    );
 
     const bots = [
       "GPTBot",
@@ -25,7 +27,9 @@ test.describe("agent-ready endpoints", () => {
       expect(body).toContain(`User-agent: ${bot}`);
     }
 
-    expect(body).toContain("Content-Signals: search, ai-train: yes");
+    expect(body).toContain(
+      "Content-Signal: search=yes, ai-input=yes, ai-train=yes",
+    );
     expect(body).toMatch(/^Sitemap: https?:\/\/.+\/sitemap-index\.xml$/m);
   });
 

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -14,8 +14,11 @@ const AI_BOTS = [
   "Amazonbot",
 ];
 
-// https://contentsignals.org — opt-in signal for how crawled content may be used.
-const CONTENT_SIGNALS = "search, ai-train: yes";
+// https://contentsignals.org — declares how crawled content may be used after
+// access. Three signals: search (index & link), ai-input (RAG / live answers),
+// ai-train (model training). Default to yes to keep the starter "agent-ready".
+// Goes inside a User-agent group; the directive name is singular per the spec.
+const CONTENT_SIGNAL = "search=yes, ai-input=yes, ai-train=yes";
 
 export const GET: APIRoute = ({ site }) => {
   if (!site) {
@@ -25,16 +28,17 @@ export const GET: APIRoute = ({ site }) => {
   const lines: string[] = [];
 
   lines.push("User-agent: *");
+  lines.push(`Content-Signal: ${CONTENT_SIGNAL}`);
   lines.push("Allow: /");
   lines.push("");
 
   for (const bot of AI_BOTS) {
     lines.push(`User-agent: ${bot}`);
+    lines.push(`Content-Signal: ${CONTENT_SIGNAL}`);
     lines.push("Allow: /");
     lines.push("");
   }
 
-  lines.push(`Content-Signals: ${CONTENT_SIGNALS}`);
   lines.push(`Sitemap: ${new URL("sitemap-index.xml", site).href}`);
 
   return new Response(lines.join("\n") + "\n", {


### PR DESCRIPTION
The robots.txt generator emitted a non-conformant `Content-Signals: search,
ai-train: yes` line placed outside any User-agent group. Per the Content
Signals spec (contentsignals.org), the directive is singular `Content-Signal`,
uses `key=value` pairs, and must live inside a User-agent group.

Emit `Content-Signal: search=yes, ai-input=yes, ai-train=yes` within each
User-agent group, declaring an agent-ready stance across all three signals
(search, ai-input, ai-train). Update the e2e assertions to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YTuVg22DM6b7tVi9KdPwf3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the site’s `robots.txt` output to use a clearer, standardized content-signal format.
  * Improved the robots response so it now includes the expected `User-agent`, `Allow`, and content-signal lines in the correct structure.
  * Tightened automated checks to verify the full robots text format, helping prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->