### PR TITLE
redirect bear-fit.haspar.us to the PartyKit deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,11 @@
     {
       "source": "/rpg",
       "destination": "https://lol.haspar.us"
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "bear-fit.haspar.us" }],
+      "destination": "https://bear-fit.hasparus.partykit.dev/:path*"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,12 @@
   "redirects": [
     {
       "source": "/s/:path*",
+      "has": [{ "type": "host", "value": "haspar.us" }],
       "destination": "https://hasparus-url-shortener.builtwithdark.com/:path*"
     },
     {
       "source": "/rpg",
+      "has": [{ "type": "host", "value": "haspar.us" }],
       "destination": "https://lol.haspar.us"
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing support so all pages on `bear-fit.haspar.us` redirect to their corresponding locations on the hosted application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->